### PR TITLE
fix: resolve silver-processing deployment failures and remove SQS

### DIFF
--- a/apps/silver-processing/Dockerfile
+++ b/apps/silver-processing/Dockerfile
@@ -29,4 +29,4 @@ WORKDIR ${LAMBDA_TASK_ROOT}
 COPY apps/silver-processing/app ./app
 
 # Lambda handler
-CMD ["app.handlers.lambda_handler"]
+CMD ["app.lambda_handler.lambda_handler"]

--- a/apps/silver-processing/app/lambda_handler.py
+++ b/apps/silver-processing/app/lambda_handler.py
@@ -1,0 +1,11 @@
+"""
+Lambda handler entry point for silver-processing.
+
+This module provides the lambda_handler function that matches the expected
+module structure for Lambda deployment health checks.
+"""
+
+from .handlers import lambda_handler
+
+# Re-export the lambda_handler function for Lambda runtime
+__all__ = ["lambda_handler"]

--- a/apps/silver-processing/tests/test_lambda_deployment.py
+++ b/apps/silver-processing/tests/test_lambda_deployment.py
@@ -83,10 +83,10 @@ class TestLambdaDeployment:
             dockerfile_content = f.read()
 
         # Check that the CMD points to the correct handler
-        assert 'CMD ["app.handlers.lambda_handler"]' in dockerfile_content
+        assert 'CMD ["app.lambda_handler.lambda_handler"]' in dockerfile_content
 
         # Verify the handler function exists and is callable
-        from app.handlers import lambda_handler
+        from app.lambda_handler import lambda_handler
 
         assert callable(lambda_handler)
 

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -122,11 +122,12 @@ output "lambda_functions" {
       function_arn  = aws_lambda_function.bronze_ingestion.arn
       invoke_arn    = aws_lambda_function.bronze_ingestion.invoke_arn
     }
-    mcp_server = {
-      function_name = aws_lambda_function.mcp_server.function_name
-      function_arn  = aws_lambda_function.mcp_server.arn
-      invoke_arn    = aws_lambda_function.mcp_server.invoke_arn
-    }
+    # mcp_server commented out until image is available
+    # mcp_server = {
+    #   function_name = aws_lambda_function.mcp_server.function_name
+    #   function_arn  = aws_lambda_function.mcp_server.arn
+    #   invoke_arn    = aws_lambda_function.mcp_server.invoke_arn
+    # }
   }
 }
 


### PR DESCRIPTION
- Remove SQS queues (overkill for hobby project scope)
- Comment out mcp-server Lambda until image exists
- Add lambda_handler.py module for proper health checks
- Update Dockerfile CMD to match bronze-ingestion pattern
- Simplify error handling to use Lambda retries + CloudWatch

Co-authored-by: GitHub Copilot

This is intended to address yesterday's deployment failures