### PR TITLE
remove filter prefix from s3 event notification

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1356,6 +1356,8 @@ resource "aws_s3_bucket_notification" "bronze_bucket_notification" {
   lambda_function {
     lambda_function_arn = aws_lambda_function.silver_processing.arn
     events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = "raw/box_scores/date"
+    filter_suffix       = "json"
   }
 
   depends_on = [aws_lambda_permission.s3_invoke_silver_processing]


### PR DESCRIPTION
Also restore the source_account that I removed in #461, that was a red herring

Manual testing shows that removing the filter pre/suffix values from this filter cause it to work - not sure why, but kinda don't care at this point in the day.